### PR TITLE
build: update Gradle Java toolchain to 25

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ version = '1.3.0'
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 


### PR DESCRIPTION
### Motivation
- Raise the project Java toolchain target to Java 25 so builds use the newer language level specified by `JavaLanguageVersion.of(25)`.

### Description
- Change the Gradle Java toolchain configuration in `build.gradle` from `JavaLanguageVersion.of(21)` to `JavaLanguageVersion.of(25)`.

### Testing
- Ran `gradle -q help`, which failed in this environment with `Unsupported class file major version 69` due to local Gradle/JDK compatibility and not the source change itself.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d410ca2aec832f8ea409b3df0bb5c2)