### PR TITLE
Update plugin.yml api-version to 1.21.1

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: DeathsToDiscord
 version: 1.3.0
 main: com.pinnacle.deathstodiscord.DeathsToDiscordPlugin
-api-version: '1.21'
+api-version: '1.21.1'
 author: Kevin
 
 commands:


### PR DESCRIPTION
### Motivation
- Align the plugin `api-version` with the project's Paper API target (1.21.1) to prevent compatibility issues at runtime.

### Description
- Changed `api-version` in `src/main/resources/plugin.yml` from `'1.21'` to `'1.21.1'` and left the commands and permissions blocks unchanged.

### Testing
- Verified the Paper API dependency via `rg -n "paper|spigot|api-version|minecraft|1\.21|paper-api"` and inspected `src/main/resources/plugin.yml` with `sed`/`nl` to confirm the `api-version` line was updated; these checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1f25c3038832f8655914893c2f3ac)