### PR TITLE
Update Paper API dependency to 1.21.8-R0.1-SNAPSHOT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly "io.papermc.paper:paper-api:1.21.1-R0.1-SNAPSHOT"
+    compileOnly "io.papermc.paper:paper-api:1.21.8-R0.1-SNAPSHOT"
 }
 
 tasks.withType(JavaCompile).configureEach {


### PR DESCRIPTION
### Motivation
- Align the `compileOnly` Paper API declared in `build.gradle` with the intended runtime server compatibility target (`26.1.2 build #52`).

### Description
- Replace the dependency line `compileOnly "io.papermc.paper:paper-api:1.21.1-R0.1-SNAPSHOT"` with `compileOnly "io.papermc.paper:paper-api:1.21.8-R0.1-SNAPSHOT"` and leave the PaperMC repository `maven { url = 'https://repo.papermc.io/repository/maven-public/' }` unchanged.

### Testing
- No automated build or unit tests were executed because this is a manifest-only dependency change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1f25d7db4832fbb815975e5bd755e)