### PR TITLE
Bump plugin version to 1.4-beta 1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'com.pinnacle'
-version = '1.3.0'
+version = '1.4-beta 1'
 
 java {
     toolchain {

--- a/src/main/java/com/pinnacle/deathstodiscord/DeathsToDiscordPlugin.java
+++ b/src/main/java/com/pinnacle/deathstodiscord/DeathsToDiscordPlugin.java
@@ -61,7 +61,7 @@ public class DeathsToDiscordPlugin extends JavaPlugin implements Listener, TabEx
             }
         });
 
-        getLogger().info("DeathsToDiscord v1.3.0 enabled. Updates will post on every death.");
+        getLogger().info("DeathsToDiscord v1.4-beta 1 enabled. Updates will post on every death.");
     }
 
     @EventHandler

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: DeathsToDiscord
-version: 1.3.0
+version: 1.4-beta 1
 main: com.pinnacle.deathstodiscord.DeathsToDiscordPlugin
 api-version: '1.21'
 author: Kevin


### PR DESCRIPTION
### Motivation
- Ensure the build artifact, plugin metadata, and runtime logging all report the same release identifier to avoid confusion from mismatched versions.
- Prepare the codebase for the Paper-compatible update by setting the new release number `1.4-beta 1` consistently across the project.

### Description
- Updated the Gradle project `version` to `1.4-beta 1` in `build.gradle` so produced artifacts carry the new identifier.
- Updated the plugin metadata `version` to `1.4-beta 1` in `src/main/resources/plugin.yml` so the plugin reports the correct version at runtime.
- Updated the startup log line in `DeathsToDiscordPlugin#onEnable` to `DeathsToDiscord v1.4-beta 1 enabled.` for consistent logging visibility.

### Testing
- Ran `git diff -- build.gradle src/main/resources/plugin.yml src/main/java/com/pinnacle/deathstodiscord/DeathsToDiscordPlugin.java` to verify the diff contained only the intended version changes, and it succeeded.
- Ran `git commit -m "Bump plugin version to 1.4-beta 1"` to record the change, and the commit succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1f253be04832f8bf6cf5d1aace5ce)