### PR TITLE
Bump Paper API to 26.1.2 and update plugin api-version to 26.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly "io.papermc.paper:paper-api:1.21.1-R0.1-SNAPSHOT"
+    compileOnly "io.papermc.paper:paper-api:26.1.2.build.52-alpha"
 }
 
 tasks.withType(JavaCompile).configureEach {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: DeathsToDiscord
 version: 1.3.0
 main: com.pinnacle.deathstodiscord.DeathsToDiscordPlugin
-api-version: '1.21'
+api-version: '26.1'
 author: Kevin
 
 commands:


### PR DESCRIPTION
### Motivation

- Align the project with a newer Paper API release to support newer Minecraft/Paper server versions and avoid API mismatches between the compiled API and plugin metadata.

### Description

- Updated the Paper API compile-only dependency in `build.gradle` from `io.papermc.paper:paper-api:1.21.1-R0.1-SNAPSHOT` to `io.papermc.paper:paper-api:26.1.2.build.52-alpha`.
- Updated the plugin `api-version` in `src/main/resources/plugin.yml` from `1.21` to `26.1` to match the upgraded API version.

### Testing

- Ran `./gradlew compileJava` which completed successfully. 
- Ran `./gradlew build` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1f147c358832f913a3e01830c8ba3)