### PR TITLE
7 deaths can be missed while a discord request is in progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to DeathsToDiscord are documented here.
+
+## [1.4.1-beta.1] - Unreleased
+
+### Added
+
+- Added automated GitHub Actions build and release workflows for Java 25/Gradle builds, tests, verified plugin artifacts, and SHA-256 checksums.
+- Added automated tests for leaderboard ordering, TOP mode behavior, Discord message-length trimming, and death-update scheduling.
+
+### Changed
+
+- Changed the Gradle project version to `1.4.1` as the base version for the `1.4.1` prerelease/stable series.
+- Changed `plugin.yml` version handling so the plugin version is sourced from Gradle during the build.
+- Pinned the Paper 26.2 API dependency to a specific build for reproducible builds.
+- Changed death-triggered update scheduling to track scheduled, in-flight, and pending update states while preserving the existing configurable debounce delay.
+
+### Fixed
+
+- Fixed issue #7: deaths that occur after a leaderboard snapshot starts, including while the Discord request is still in progress, now queue a fresh follow-up update instead of being silently missed.
+- Fixed rapid in-flight deaths so they coalesce into one follow-up update rather than producing unnecessary duplicate requests.
+- Fixed the Gradle 9.3 test runtime configuration by explicitly including the JUnit Platform launcher.

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'com.pinnacle'
-version = '1.4'
+version = '1.4.1'
 description = 'Keeps a Minecraft death leaderboard synchronized to a Discord webhook message.'
 
 java {

--- a/src/main/java/com/pinnacle/deathstodiscord/DeathsToDiscordPlugin.java
+++ b/src/main/java/com/pinnacle/deathstodiscord/DeathsToDiscordPlugin.java
@@ -31,7 +31,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 public class DeathsToDiscordPlugin extends JavaPlugin implements Listener, TabExecutor {
@@ -40,7 +39,7 @@ public class DeathsToDiscordPlugin extends JavaPlugin implements Listener, TabEx
     private static final int DEFAULT_DISCORD_CONTENT_LIMIT = 1900;
     private static final int MIN_DISCORD_CONTENT_LIMIT = 500;
 
-    private final AtomicBoolean updateScheduled = new AtomicBoolean(false);
+    private final UpdateCycleState deathUpdateState = new UpdateCycleState();
     private HttpClient http;
 
     @Override
@@ -70,11 +69,26 @@ public class DeathsToDiscordPlugin extends JavaPlugin implements Listener, TabEx
 
     @EventHandler
     public void onPlayerDeath(PlayerDeathEvent event) {
-        int delaySeconds = Math.max(0, getConfig().getInt("update-delay-seconds", 2));
-        long delayTicks = delaySeconds * 20L;
+        if (deathUpdateState.requestUpdate()) {
+            scheduleDeathUpdate(getUpdateDelayTicks());
+        }
+    }
 
-        if (updateScheduled.compareAndSet(false, true)) {
-            Bukkit.getScheduler().runTaskLater(this, () -> updateDiscordLeaderboard(null, () -> updateScheduled.set(false)), delayTicks);
+    private long getUpdateDelayTicks() {
+        int delaySeconds = Math.max(0, getConfig().getInt("update-delay-seconds", 2));
+        return delaySeconds * 20L;
+    }
+
+    private void scheduleDeathUpdate(long delayTicks) {
+        Bukkit.getScheduler().runTaskLater(this, () -> {
+            deathUpdateState.markUpdateStarted();
+            updateDiscordLeaderboard(null, this::completeDeathUpdate);
+        }, delayTicks);
+    }
+
+    private void completeDeathUpdate() {
+        if (deathUpdateState.completeUpdateAndShouldScheduleAgain()) {
+            scheduleDeathUpdate(getUpdateDelayTicks());
         }
     }
 

--- a/src/main/java/com/pinnacle/deathstodiscord/UpdateCycleState.java
+++ b/src/main/java/com/pinnacle/deathstodiscord/UpdateCycleState.java
@@ -1,0 +1,57 @@
+package com.pinnacle.deathstodiscord;
+
+/**
+ * Tracks the lifecycle of death-triggered leaderboard updates.
+ *
+ * <p>Deaths that happen while an update is only waiting for its debounce delay
+ * are already covered by the upcoming snapshot, so they do not need another
+ * update. Deaths that happen after the snapshot has started are marked pending
+ * so one fresh follow-up snapshot is scheduled when the current update ends.</p>
+ */
+final class UpdateCycleState {
+
+    private Phase phase = Phase.IDLE;
+    private boolean pending;
+
+    synchronized boolean requestUpdate() {
+        return switch (phase) {
+            case IDLE -> {
+                phase = Phase.SCHEDULED;
+                yield true;
+            }
+            case SCHEDULED -> false;
+            case IN_FLIGHT -> {
+                pending = true;
+                yield false;
+            }
+        };
+    }
+
+    synchronized void markUpdateStarted() {
+        if (phase != Phase.SCHEDULED) {
+            throw new IllegalStateException("Cannot start an update while state is " + phase);
+        }
+        phase = Phase.IN_FLIGHT;
+    }
+
+    synchronized boolean completeUpdateAndShouldScheduleAgain() {
+        if (phase != Phase.IN_FLIGHT) {
+            throw new IllegalStateException("Cannot complete an update while state is " + phase);
+        }
+
+        if (pending) {
+            pending = false;
+            phase = Phase.SCHEDULED;
+            return true;
+        }
+
+        phase = Phase.IDLE;
+        return false;
+    }
+
+    private enum Phase {
+        IDLE,
+        SCHEDULED,
+        IN_FLIGHT
+    }
+}

--- a/src/test/java/com/pinnacle/deathstodiscord/UpdateCycleStateTest.java
+++ b/src/test/java/com/pinnacle/deathstodiscord/UpdateCycleStateTest.java
@@ -1,0 +1,71 @@
+package com.pinnacle.deathstodiscord;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class UpdateCycleStateTest {
+
+    @Test
+    void deathsDuringDebounceDoNotScheduleRedundantFollowUp() {
+        UpdateCycleState state = new UpdateCycleState();
+
+        assertTrue(state.requestUpdate());
+        assertFalse(state.requestUpdate());
+        assertFalse(state.requestUpdate());
+
+        state.markUpdateStarted();
+
+        assertFalse(state.completeUpdateAndShouldScheduleAgain());
+        assertTrue(state.requestUpdate());
+    }
+
+    @Test
+    void deathDuringInFlightUpdateSchedulesFreshFollowUp() {
+        UpdateCycleState state = new UpdateCycleState();
+
+        assertTrue(state.requestUpdate());
+        state.markUpdateStarted();
+
+        assertFalse(state.requestUpdate());
+        assertTrue(state.completeUpdateAndShouldScheduleAgain());
+
+        state.markUpdateStarted();
+        assertFalse(state.completeUpdateAndShouldScheduleAgain());
+        assertTrue(state.requestUpdate());
+    }
+
+    @Test
+    void multipleDeathsDuringInFlightUpdateCoalesceIntoOneFollowUp() {
+        UpdateCycleState state = new UpdateCycleState();
+
+        assertTrue(state.requestUpdate());
+        state.markUpdateStarted();
+
+        assertFalse(state.requestUpdate());
+        assertFalse(state.requestUpdate());
+        assertFalse(state.requestUpdate());
+
+        assertTrue(state.completeUpdateAndShouldScheduleAgain());
+        state.markUpdateStarted();
+        assertFalse(state.completeUpdateAndShouldScheduleAgain());
+    }
+
+    @Test
+    void deathDuringFollowUpCanQueueAnotherFreshSnapshot() {
+        UpdateCycleState state = new UpdateCycleState();
+
+        assertTrue(state.requestUpdate());
+        state.markUpdateStarted();
+        assertFalse(state.requestUpdate());
+        assertTrue(state.completeUpdateAndShouldScheduleAgain());
+
+        state.markUpdateStarted();
+        assertFalse(state.requestUpdate());
+        assertTrue(state.completeUpdateAndShouldScheduleAgain());
+
+        state.markUpdateStarted();
+        assertFalse(state.completeUpdateAndShouldScheduleAgain());
+    }
+}


### PR DESCRIPTION
Replaced the single update flag with an update-cycle state tracker.
Deaths during the normal debounce window still combine into one update.
Deaths occurring after the leaderboard snapshot begins or while Discord is being contacted now mark the leaderboard as needing another refresh.
After the current update completes, one fresh update is automatically scheduled.
Multiple deaths during the same in-flight request collapse into one follow-up rather than spamming Discord.
Added regression tests covering those scenarios.
Set the base project version to 1.4.1 for releases such as 1.4.1-beta.1.