### PR TITLE
Fix duplicate initial leaderboard messages for issue 9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,23 @@
 
 All notable changes to DeathsToDiscord are documented here.
 
-## [1.4.1-beta.1] - Unreleased
+## [1.4.1-beta.2] - Unreleased
+
+### Added
+
+- Added regression tests for initial Discord message creation coordination, including overlapping update requests and failed creation attempts.
+
+### Changed
+
+- Changed overlapping startup, reload, and death-triggered updates to wait for an in-progress initial Discord message creation when `message-id` is blank.
+- Preserved the existing 1.4/1.4.1 configuration format and saved `message-id` behavior; no configuration migration is required.
+
+### Fixed
+
+- Fixed issue #9: multiple overlapping updates can no longer create multiple Discord leaderboard messages while `message-id` is blank.
+- Fixed queued updates after a failed initial message creation so their completion callbacks are released instead of remaining stuck.
+
+## [1.4.1-beta.1] - Released - 2026-08-19
 
 ### Added
 

--- a/src/main/java/com/pinnacle/deathstodiscord/DeathsToDiscordPlugin.java
+++ b/src/main/java/com/pinnacle/deathstodiscord/DeathsToDiscordPlugin.java
@@ -40,6 +40,7 @@ public class DeathsToDiscordPlugin extends JavaPlugin implements Listener, TabEx
     private static final int MIN_DISCORD_CONTENT_LIMIT = 500;
 
     private final UpdateCycleState deathUpdateState = new UpdateCycleState();
+    private final MessageCreationGate messageCreationGate = new MessageCreationGate();
     private HttpClient http;
 
     @Override
@@ -144,6 +145,14 @@ public class DeathsToDiscordPlugin extends JavaPlugin implements Listener, TabEx
 
         String messageId = getConfig().getString("message-id", "");
         if (messageId == null || messageId.isBlank()) {
+            boolean shouldCreateMessage = messageCreationGate.beginOrQueue(
+                    () -> updateDiscordLeaderboard(sender, onComplete),
+                    failureMessage -> completeWithFailure(sender, failureMessage, onComplete));
+
+            if (!shouldCreateMessage) {
+                return;
+            }
+
             createDiscordMessageThenPatch(webhookUrl, content, sender, onComplete);
             return;
         }
@@ -228,10 +237,15 @@ public class DeathsToDiscordPlugin extends JavaPlugin implements Listener, TabEx
                     getConfig().set("message-id", createdMessageId);
                     saveConfig();
                     getLogger().info("Created Discord message. Saved message-id=" + createdMessageId);
+                    messageCreationGate.creationSucceeded();
                     patchDiscordMessageAsync(webhookUrl, createdMessageId, content, sender, onComplete);
                 });
             } catch (Exception e) {
-                completeWithFailure(sender, "Discord message creation failed: " + e.getMessage(), onComplete);
+                String failureMessage = "Discord message creation failed: " + e.getMessage();
+                Bukkit.getScheduler().runTask(this, () -> {
+                    messageCreationGate.creationFailed(failureMessage);
+                    completeWithFailure(sender, failureMessage, onComplete);
+                });
             }
         });
     }

--- a/src/main/java/com/pinnacle/deathstodiscord/MessageCreationGate.java
+++ b/src/main/java/com/pinnacle/deathstodiscord/MessageCreationGate.java
@@ -1,0 +1,61 @@
+package com.pinnacle.deathstodiscord;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+/**
+ * Coordinates creation of the initial Discord leaderboard message.
+ *
+ * <p>All access is expected from the Bukkit primary thread. The first caller
+ * claims message creation; later callers are queued until that creation either
+ * succeeds or fails.</p>
+ */
+final class MessageCreationGate {
+
+    private boolean creationInProgress;
+    private final List<WaitingUpdate> waitingUpdates = new ArrayList<>();
+
+    boolean beginOrQueue(Runnable retryAfterCreation, Consumer<String> failAfterCreation) {
+        if (!creationInProgress) {
+            creationInProgress = true;
+            return true;
+        }
+
+        waitingUpdates.add(new WaitingUpdate(retryAfterCreation, failAfterCreation));
+        return false;
+    }
+
+    void creationSucceeded() {
+        creationInProgress = false;
+        List<WaitingUpdate> waiting = drainWaitingUpdates();
+        waiting.forEach(update -> update.retryAfterCreation().run());
+    }
+
+    void creationFailed(String reason) {
+        creationInProgress = false;
+        List<WaitingUpdate> waiting = drainWaitingUpdates();
+        waiting.forEach(update -> update.failAfterCreation().accept(reason));
+    }
+
+    boolean isCreationInProgress() {
+        return creationInProgress;
+    }
+
+    int queuedUpdateCount() {
+        return waitingUpdates.size();
+    }
+
+    private List<WaitingUpdate> drainWaitingUpdates() {
+        if (waitingUpdates.isEmpty()) {
+            return List.of();
+        }
+
+        List<WaitingUpdate> waiting = List.copyOf(waitingUpdates);
+        waitingUpdates.clear();
+        return waiting;
+    }
+
+    private record WaitingUpdate(Runnable retryAfterCreation, Consumer<String> failAfterCreation) {
+    }
+}

--- a/src/test/java/com/pinnacle/deathstodiscord/MessageCreationGateTest.java
+++ b/src/test/java/com/pinnacle/deathstodiscord/MessageCreationGateTest.java
@@ -1,0 +1,67 @@
+package com.pinnacle.deathstodiscord;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MessageCreationGateTest {
+
+    @Test
+    void overlappingUpdatesWaitForTheFirstMessageCreation() {
+        MessageCreationGate gate = new MessageCreationGate();
+        List<String> events = new ArrayList<>();
+
+        assertTrue(gate.beginOrQueue(
+                () -> events.add("first-retry"),
+                reason -> events.add("first-failed:" + reason)));
+
+        assertFalse(gate.beginOrQueue(
+                () -> events.add("second-retry"),
+                reason -> events.add("second-failed:" + reason)));
+        assertFalse(gate.beginOrQueue(
+                () -> events.add("third-retry"),
+                reason -> events.add("third-failed:" + reason)));
+
+        assertTrue(gate.isCreationInProgress());
+        assertEquals(2, gate.queuedUpdateCount());
+
+        gate.creationSucceeded();
+
+        assertFalse(gate.isCreationInProgress());
+        assertEquals(0, gate.queuedUpdateCount());
+        assertEquals(List.of("second-retry", "third-retry"), events);
+    }
+
+    @Test
+    void queuedUpdatesCompleteWithoutRetryingWhenCreationFails() {
+        MessageCreationGate gate = new MessageCreationGate();
+        List<String> events = new ArrayList<>();
+
+        assertTrue(gate.beginOrQueue(
+                () -> events.add("first-retry"),
+                reason -> events.add("first-failed:" + reason)));
+        assertFalse(gate.beginOrQueue(
+                () -> events.add("second-retry"),
+                reason -> events.add("second-failed:" + reason)));
+
+        gate.creationFailed("creation failed");
+
+        assertFalse(gate.isCreationInProgress());
+        assertEquals(0, gate.queuedUpdateCount());
+        assertEquals(List.of("second-failed:creation failed"), events);
+    }
+
+    @Test
+    void gateCanBeClaimedAgainAfterCompletion() {
+        MessageCreationGate gate = new MessageCreationGate();
+
+        assertTrue(gate.beginOrQueue(() -> { }, reason -> { }));
+        gate.creationSucceeded();
+        assertTrue(gate.beginOrQueue(() -> { }, reason -> { }));
+    }
+}


### PR DESCRIPTION
Added a MessageCreationGate so only one update can create the initial Discord leaderboard message.
If startup, /d2d reload, or a death update overlaps while message-id is blank, later requests now wait for the first creation instead of POSTing another Discord message.
Once the first message ID is saved, queued updates resume using that same message.
If initial message creation fails, queued updates are properly released rather than getting stuck.
Added regression tests for successful and failed overlapping creation attempts.