### PR TITLE
Fix concurrent PATCH ordering for issue 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,21 @@ All notable changes to DeathsToDiscord are documented here.
 ### Added
 
 - Added regression tests for initial Discord message creation coordination, including overlapping update requests and failed creation attempts.
+- Added regression tests for serialized Discord PATCH ordering and for keeping fresh post-creation updates behind the creator PATCH.
 
 ### Changed
 
 - Changed overlapping startup, reload, and death-triggered updates to wait for an in-progress initial Discord message creation when `message-id` is blank.
+- Changed Discord leaderboard PATCH requests to run serially in submission order instead of concurrently.
+- Changed initial message creation so its captured leaderboard PATCH completes before queued updates are released to rebuild and submit fresher snapshots.
 - Preserved the existing 1.4/1.4.1 configuration format and saved `message-id` behavior; no configuration migration is required.
 
 ### Fixed
 
 - Fixed issue #9: multiple overlapping updates can no longer create multiple Discord leaderboard messages while `message-id` is blank.
 - Fixed queued updates after a failed initial message creation so their completion callbacks are released instead of remaining stuck.
+- Fixed issue #10: concurrent PATCH requests can no longer finish out of order and allow an older leaderboard snapshot to overwrite a newer one.
+- Fixed the initial-message race where queued fresh updates could be released before the creator's older PATCH, allowing the stale creator snapshot to become the final Discord message.
 
 ## [1.4.1-beta.1] - Released - 2026-08-19
 

--- a/src/main/java/com/pinnacle/deathstodiscord/DeathsToDiscordPlugin.java
+++ b/src/main/java/com/pinnacle/deathstodiscord/DeathsToDiscordPlugin.java
@@ -41,6 +41,7 @@ public class DeathsToDiscordPlugin extends JavaPlugin implements Listener, TabEx
 
     private final UpdateCycleState deathUpdateState = new UpdateCycleState();
     private final MessageCreationGate messageCreationGate = new MessageCreationGate();
+    private final PatchRequestQueue patchRequestQueue = new PatchRequestQueue();
     private HttpClient http;
 
     @Override
@@ -237,8 +238,14 @@ public class DeathsToDiscordPlugin extends JavaPlugin implements Listener, TabEx
                     getConfig().set("message-id", createdMessageId);
                     saveConfig();
                     getLogger().info("Created Discord message. Saved message-id=" + createdMessageId);
-                    messageCreationGate.creationSucceeded();
-                    patchDiscordMessageAsync(webhookUrl, createdMessageId, content, sender, onComplete);
+
+                    // Keep the creation gate closed until this captured snapshot has
+                    // completed its PATCH attempt. Any updates that arrived while the
+                    // POST was in flight will then rebuild and queue behind it.
+                    patchDiscordMessageAsync(webhookUrl, createdMessageId, content, sender, () -> {
+                        messageCreationGate.creationSucceeded();
+                        onComplete.run();
+                    });
                 });
             } catch (Exception e) {
                 String failureMessage = "Discord message creation failed: " + e.getMessage();
@@ -251,14 +258,45 @@ public class DeathsToDiscordPlugin extends JavaPlugin implements Listener, TabEx
     }
 
     private void patchDiscordMessageAsync(String webhookUrl, String messageId, String content, CommandSender sender, Runnable onComplete) {
+        if (!Bukkit.isPrimaryThread()) {
+            Bukkit.getScheduler().runTask(this, () -> patchDiscordMessageAsync(webhookUrl, messageId, content, sender, onComplete));
+            return;
+        }
+
+        patchRequestQueue.submit(() -> executeDiscordPatchAsync(webhookUrl, messageId, content, sender, onComplete));
+    }
+
+    private void executeDiscordPatchAsync(String webhookUrl, String messageId, String content, CommandSender sender, Runnable onComplete) {
         Bukkit.getScheduler().runTaskAsynchronously(this, () -> {
+            String failureMessage = null;
             try {
                 discordWebhookPatchMessage(webhookUrl, messageId, content);
-                completeSuccessfully(sender, onComplete);
             } catch (Exception e) {
-                completeWithFailure(sender, "Discord leaderboard update failed: " + e.getMessage(), onComplete);
+                failureMessage = "Discord leaderboard update failed: " + e.getMessage();
             }
+
+            String finalFailureMessage = failureMessage;
+            Bukkit.getScheduler().runTask(this, () -> finishSerializedPatch(sender, finalFailureMessage, onComplete));
         });
+    }
+
+    private void finishSerializedPatch(CommandSender sender, String failureMessage, Runnable onComplete) {
+        try {
+            if (failureMessage == null) {
+                if (sender != null) {
+                    sender.sendMessage(Component.text("DeathsToDiscord Discord message updated.", NamedTextColor.GREEN));
+                }
+            } else {
+                if (sender != null) {
+                    sender.sendMessage(Component.text("Update failed: " + failureMessage, NamedTextColor.RED));
+                }
+                getLogger().warning(failureMessage);
+            }
+
+            onComplete.run();
+        } finally {
+            patchRequestQueue.completeCurrent();
+        }
     }
 
     private void completeSuccessfully(CommandSender sender, Runnable onComplete) {

--- a/src/main/java/com/pinnacle/deathstodiscord/PatchRequestQueue.java
+++ b/src/main/java/com/pinnacle/deathstodiscord/PatchRequestQueue.java
@@ -1,0 +1,52 @@
+package com.pinnacle.deathstodiscord;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Objects;
+
+/**
+ * Serializes Discord message PATCH requests in submission order.
+ *
+ * <p>All access is expected from the Bukkit primary thread. A submitted patch
+ * starts immediately when the queue is idle; later submissions wait until the
+ * current patch reports completion.</p>
+ */
+final class PatchRequestQueue {
+
+    private boolean patchInProgress;
+    private final Deque<Runnable> waitingPatches = new ArrayDeque<>();
+
+    void submit(Runnable startPatch) {
+        Objects.requireNonNull(startPatch, "startPatch");
+
+        if (!patchInProgress) {
+            patchInProgress = true;
+            startPatch.run();
+            return;
+        }
+
+        waitingPatches.addLast(startPatch);
+    }
+
+    void completeCurrent() {
+        if (!patchInProgress) {
+            return;
+        }
+
+        Runnable next = waitingPatches.pollFirst();
+        if (next == null) {
+            patchInProgress = false;
+            return;
+        }
+
+        next.run();
+    }
+
+    boolean isPatchInProgress() {
+        return patchInProgress;
+    }
+
+    int queuedPatchCount() {
+        return waitingPatches.size();
+    }
+}

--- a/src/test/java/com/pinnacle/deathstodiscord/PatchRequestQueueTest.java
+++ b/src/test/java/com/pinnacle/deathstodiscord/PatchRequestQueueTest.java
@@ -1,0 +1,79 @@
+package com.pinnacle.deathstodiscord;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PatchRequestQueueTest {
+
+    @Test
+    void serializesPatchesInSubmissionOrder() {
+        PatchRequestQueue queue = new PatchRequestQueue();
+        List<String> started = new ArrayList<>();
+
+        queue.submit(() -> started.add("first"));
+        queue.submit(() -> started.add("second"));
+        queue.submit(() -> started.add("third"));
+
+        assertEquals(List.of("first"), started);
+        assertTrue(queue.isPatchInProgress());
+        assertEquals(2, queue.queuedPatchCount());
+
+        queue.completeCurrent();
+        assertEquals(List.of("first", "second"), started);
+        assertEquals(1, queue.queuedPatchCount());
+
+        queue.completeCurrent();
+        assertEquals(List.of("first", "second", "third"), started);
+        assertEquals(0, queue.queuedPatchCount());
+
+        queue.completeCurrent();
+        assertFalse(queue.isPatchInProgress());
+    }
+
+    @Test
+    void freshCreationUpdateWaitsBehindCreatorPatch() {
+        PatchRequestQueue patchQueue = new PatchRequestQueue();
+        MessageCreationGate creationGate = new MessageCreationGate();
+        List<String> started = new ArrayList<>();
+
+        assertTrue(creationGate.beginOrQueue(
+                () -> started.add("unexpected-creator-retry"),
+                failure -> started.add("unexpected-creator-failure")));
+
+        assertFalse(creationGate.beginOrQueue(
+                () -> patchQueue.submit(() -> started.add("fresh")),
+                failure -> started.add("queued-failure")));
+
+        patchQueue.submit(() -> started.add("creator"));
+        assertEquals(List.of("creator"), started);
+
+        // The POST has succeeded and the creator PATCH has completed its HTTP
+        // request, but the serialized queue has not released the slot yet.
+        // Releasing the creation gate must therefore queue the fresh PATCH.
+        creationGate.creationSucceeded();
+        assertEquals(List.of("creator"), started);
+        assertEquals(1, patchQueue.queuedPatchCount());
+
+        patchQueue.completeCurrent();
+        assertEquals(List.of("creator", "fresh"), started);
+    }
+
+    @Test
+    void queueCanBeReusedAfterItDrains() {
+        PatchRequestQueue queue = new PatchRequestQueue();
+        List<String> started = new ArrayList<>();
+
+        queue.submit(() -> started.add("first"));
+        queue.completeCurrent();
+        queue.submit(() -> started.add("second"));
+
+        assertEquals(List.of("first", "second"), started);
+        assertTrue(queue.isPatchInProgress());
+    }
+}


### PR DESCRIPTION
Added a FIFO PatchRequestQueue so only one Discord PATCH can be in flight at a time.
Multiple /d2d reload, death-triggered, or other PATCH updates now execute in the same order they were submitted.
A failed PATCH still releases the queue so later updates aren't permanently blocked.
Fixed the additional race we discussed:
initial POST captures an older leaderboard
newer update arrives
creator's PATCH now stays ahead of the newer queued PATCH
newer snapshot is therefore guaranteed to be the final state
Added regression tests for normal PATCH ordering and the creator-vs-fresh-update scenario.