### PR TITLE
Fix webhook token exposure in error logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,14 @@ All notable changes to DeathsToDiscord are documented here.
 
 - Added regression tests for initial Discord message creation coordination, including overlapping update requests and failed creation attempts.
 - Added regression tests for serialized Discord PATCH ordering and for keeping fresh post-creation updates behind the creator PATCH.
+- Added regression tests that verify Discord webhook secrets are removed from exception messages before they can be logged or shown to administrators.
 
 ### Changed
 
 - Changed overlapping startup, reload, and death-triggered updates to wait for an in-progress initial Discord message creation when `message-id` is blank.
 - Changed Discord leaderboard PATCH requests to run serially in submission order instead of concurrently.
 - Changed initial message creation so its captured leaderboard PATCH completes before queued updates are released to rebuild and submit fresher snapshots.
+- Changed Discord request error handling to sanitize exception details before reporting failures while preserving useful non-secret diagnostics.
 - Preserved the existing 1.4/1.4.1 configuration format and saved `message-id` behavior; no configuration migration is required.
 
 ### Fixed
@@ -22,6 +24,11 @@ All notable changes to DeathsToDiscord are documented here.
 - Fixed queued updates after a failed initial message creation so their completion callbacks are released instead of remaining stuck.
 - Fixed issue #10: concurrent PATCH requests can no longer finish out of order and allow an older leaderboard snapshot to overwrite a newer one.
 - Fixed the initial-message race where queued fresh updates could be released before the creator's older PATCH, allowing the stale creator snapshot to become the final Discord message.
+
+### Security
+
+- Fixed issue #13: malformed webhook URLs and related Discord request exceptions can no longer expose the configured webhook URL or token through server logs or administrator-facing failure messages.
+- Added defense-in-depth redaction for Discord webhook URLs found in exception text even when they do not exactly match the currently configured webhook value.
 
 ## [1.4.1-beta.1] - Released - 2026-08-19
 

--- a/src/main/java/com/pinnacle/deathstodiscord/DeathsToDiscordPlugin.java
+++ b/src/main/java/com/pinnacle/deathstodiscord/DeathsToDiscordPlugin.java
@@ -248,7 +248,8 @@ public class DeathsToDiscordPlugin extends JavaPlugin implements Listener, TabEx
                     });
                 });
             } catch (Exception e) {
-                String failureMessage = "Discord message creation failed: " + e.getMessage();
+                String safeDetails = WebhookSecretRedactor.safeExceptionMessage(e, webhookUrl);
+                String failureMessage = "Discord message creation failed: " + safeDetails;
                 Bukkit.getScheduler().runTask(this, () -> {
                     messageCreationGate.creationFailed(failureMessage);
                     completeWithFailure(sender, failureMessage, onComplete);
@@ -272,7 +273,8 @@ public class DeathsToDiscordPlugin extends JavaPlugin implements Listener, TabEx
             try {
                 discordWebhookPatchMessage(webhookUrl, messageId, content);
             } catch (Exception e) {
-                failureMessage = "Discord leaderboard update failed: " + e.getMessage();
+                String safeDetails = WebhookSecretRedactor.safeExceptionMessage(e, webhookUrl);
+                failureMessage = "Discord leaderboard update failed: " + safeDetails;
             }
 
             String finalFailureMessage = failureMessage;

--- a/src/main/java/com/pinnacle/deathstodiscord/WebhookSecretRedactor.java
+++ b/src/main/java/com/pinnacle/deathstodiscord/WebhookSecretRedactor.java
@@ -1,0 +1,33 @@
+package com.pinnacle.deathstodiscord;
+
+import java.util.regex.Pattern;
+
+/**
+ * Removes Discord webhook secrets from messages before they are shown to an
+ * administrator or written to the server log.
+ */
+final class WebhookSecretRedactor {
+
+    private static final String REDACTED_WEBHOOK = "[REDACTED_WEBHOOK]";
+    private static final Pattern DISCORD_WEBHOOK_PATTERN = Pattern.compile(
+            "(?i)(https?://(?:(?:canary|ptb)\\.)?discord(?:app)?\\.com/api(?:/v\\d+)?/webhooks/\\d+/)[^\\s?&#]+"
+    );
+
+    private WebhookSecretRedactor() {
+    }
+
+    static String safeExceptionMessage(Throwable error, String configuredWebhookUrl) {
+        String message = error == null ? null : error.getMessage();
+        if (message == null || message.isBlank()) {
+            return "Discord request failed without additional details.";
+        }
+
+        String sanitized = message;
+        if (configuredWebhookUrl != null && !configuredWebhookUrl.isBlank()) {
+            sanitized = sanitized.replace(configuredWebhookUrl, REDACTED_WEBHOOK);
+        }
+
+        sanitized = DISCORD_WEBHOOK_PATTERN.matcher(sanitized).replaceAll("$1" + REDACTED_WEBHOOK);
+        return sanitized;
+    }
+}

--- a/src/test/java/com/pinnacle/deathstodiscord/WebhookSecretRedactorTest.java
+++ b/src/test/java/com/pinnacle/deathstodiscord/WebhookSecretRedactorTest.java
@@ -1,0 +1,62 @@
+package com.pinnacle.deathstodiscord;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class WebhookSecretRedactorTest {
+
+    @Test
+    void removesConfiguredWebhookUrlFromExceptionMessage() {
+        String webhook = "https://discord.com/api/webhooks/123456/super-secret-token";
+        RuntimeException error = new RuntimeException("Illegal character in URI: " + webhook);
+
+        String sanitized = WebhookSecretRedactor.safeExceptionMessage(error, webhook);
+
+        assertFalse(sanitized.contains("super-secret-token"));
+        assertFalse(sanitized.contains(webhook));
+        assertTrue(sanitized.contains("[REDACTED_WEBHOOK]"));
+    }
+
+    @Test
+    void removesConfiguredWebhookWhenExceptionAddsQueryParameters() {
+        String webhook = "https://discord.com/api/webhooks/123456/super-secret-token";
+        RuntimeException error = new RuntimeException("Invalid URI " + webhook + "?wait=true");
+
+        String sanitized = WebhookSecretRedactor.safeExceptionMessage(error, webhook);
+
+        assertFalse(sanitized.contains("super-secret-token"));
+        assertTrue(sanitized.contains("[REDACTED_WEBHOOK]?wait=true"));
+    }
+
+    @Test
+    void redactsDiscordWebhookFoundOutsideConfiguredValue() {
+        RuntimeException error = new RuntimeException(
+                "Request failed for https://canary.discord.com/api/webhooks/999999/another-secret-token");
+
+        String sanitized = WebhookSecretRedactor.safeExceptionMessage(error, "https://example.invalid/webhook");
+
+        assertFalse(sanitized.contains("another-secret-token"));
+        assertTrue(sanitized.contains("https://canary.discord.com/api/webhooks/999999/[REDACTED_WEBHOOK]"));
+    }
+
+    @Test
+    void preservesUsefulNonSecretErrorDetails() {
+        RuntimeException error = new RuntimeException("Discord HTTP 429 response: rate limited");
+
+        String sanitized = WebhookSecretRedactor.safeExceptionMessage(error, "https://discord.com/api/webhooks/1/token");
+
+        assertTrue(sanitized.contains("Discord HTTP 429"));
+        assertTrue(sanitized.contains("rate limited"));
+    }
+
+    @Test
+    void handlesMissingExceptionMessageSafely() {
+        RuntimeException error = new RuntimeException();
+
+        String sanitized = WebhookSecretRedactor.safeExceptionMessage(error, "https://discord.com/api/webhooks/1/token");
+
+        assertTrue(sanitized.contains("Discord request failed"));
+    }
+}


### PR DESCRIPTION
- Added centralized webhook-secret redaction for Discord request exceptions.
- Initial message creation failures now sanitize exception text before it reaches logs or admins.
- Serialized PATCH failures now do the same.
- The configured webhook URL is removed from error text.
- Recognizable Discord webhook URLs are also redacted as a defense-in-depth measure.
- Useful non-secret diagnostics, such as HTTP status/error information, are preserved.
- Added regression tests covering:
  - configured webhook URLs
  - URLs with appended query parameters
  - alternate Discord hosts such as Canary
  - normal non-secret errors
  - exceptions without a message

The focused redaction checks passed locally.